### PR TITLE
Rails 国際化対応

### DIFF
--- a/app/assets/stylesheets/scaffolds.css
+++ b/app/assets/stylesheets/scaffolds.css
@@ -1,0 +1,321 @@
+/****************
+Global
+****************/
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: sans-serif;
+  color: var(--global-c);
+}
+
+body {
+  padding: 24px;
+  margin: 0;
+}
+
+a:hover, a:active {
+  outline: 0;
+}
+
+a:link,
+a:visited {
+  color: var(--global-primary-c);
+}
+
+a:hover ,
+a:active {
+  color: var(--global-primary-c-hover);
+}
+
+body > br {
+  display: none;
+}
+
+body > *:first-child {
+  margin-top: 0;
+}
+
+input,
+textarea {
+  font-family: inherit;
+  outline: none;
+}
+
+input:focus-visible,
+textarea:focus-visible {
+  outline: solid 1px var(--global-primary-c);
+}
+
+img {
+  max-width: 100%;
+}
+
+p:empty {
+  display: none;
+}
+
+p:empty:first-child + * {
+  margin-top: 0;
+}
+
+input[type="submit"],
+input[type="file"],
+button[type="submit"] {
+  cursor: pointer;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  margin: 0 0 0 4px;
+  transform: translateY(0.125em);
+}
+
+input,
+button,
+a {
+  transition: all .2s ease-out;
+}
+
+/****************
+Common
+****************/
+
+:root {
+  /* border */
+  --global-bc: rgb(175, 175, 175);
+  --global-bc-muted: rgb(236, 236, 236);
+  --global-bw: 1px;
+  --global-br: 4px;
+  /* text */
+  --global-c: #444444;
+  --global-title-fz: 24px;
+  --global-headding-lh: 1.5;
+  --global-fz-md: 14px;
+  --global-fz-sm: 12px;
+  --global-label-fz: .9em;
+  --global-lh: 1.8;
+  /* primary */
+  --global-primary-c:#0088cc;
+  --global-primary-c-hover: #005580;
+  /* secondary */
+  --global-secondary-bgc: rgb(233, 233, 233);
+  --global-secondary-bgc-hover: rgb(212, 212, 212);
+  /* danger */
+  --global-danger-c: #dd2424;
+  --global-danger-bgc: #fff5f5;
+  --global-danger-bc: #fabfbf;
+  /* success */
+  --global-success-c: green;
+  /* index */
+  --global-block-gap: 12px;
+  /* single-column */
+  --single-column-w: 640px;
+}
+
+h1,
+h2 {
+  font-size: var(--global-title-fz);
+  line-height: var(--global-headding-lh);
+  margin: 1em 0;
+}
+
+h3 {
+  font-size: var(--global-fz-md);
+  line-height: var(--global-headding-lh);
+  margin: 1em 0;
+}
+
+.button_to button[type="submit"],
+.button_to input[type="submit"] {
+  background-color: var(--global-secondary-bgc);
+  border: solid var(--global-bw) var(--global-secondary-bgc-hover);
+  border-radius: var(--global-br);
+  height: 2em;
+  padding: 0 .75em;
+}
+
+.button_to button[type="submit"]:hover,
+.button_to input[type="submit"]:hover {
+  background-color: var(--global-secondary-bgc-hover);
+}
+
+/****************
+page-nav
+****************/
+
+.page-nav {
+  --nav-fz: var(--global-fz-md);
+  --nav-mt: 24px;
+  font-size: var(--nav-fz);
+  margin-top: var(--nav-mt);
+}
+
+.page-nav .button_to {
+  margin-top: var(--nav-mt);
+}
+
+/****************
+Index
+****************/
+
+.index-items {
+  display: grid;
+  gap: var(--global-block-gap);
+  grid-template-columns: repeat(auto-fill, 280px);
+  font-size: var(--global-fz-sm);
+  line-height: var(--global-lh);
+  margin-bottom: var(--nav-mt);
+}
+
+.index-item {
+  border: solid var(--global-bw) var(--global-bc);
+  padding: 16px;
+  border-radius: var(--global-br);
+  display: flex;
+  flex-direction: column;
+}
+
+.index-item div[id] {
+  flex: 1;
+}
+
+.index-item div[id] p {
+  margin: 0;
+  padding-top: 0.8em;
+  margin-bottom: 0.8em;
+  border-top: solid var(--global-bw) var(--global-bc-muted);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+}
+
+.index-item div[id] p:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.index-item strong {
+  font-size: var(--global-label-fz);
+}
+
+.index-item img {
+  max-height: 160px;
+  display: block;
+  margin: 4px auto 0;
+  object-fit: contain;
+}
+
+.index-item > p {
+  margin-bottom: 0;
+  padding: 0.8em 0 0;
+  position: relative;
+  white-space: nowrap;
+  align-self: flex-end;
+  text-align: right;
+}
+
+/****************
+Show
+****************/
+
+.show-item {
+  max-width: var(--single-column-w);
+  display: block;
+  border: solid var(--global-bw) var(--global-bc);
+  padding: 24px;
+  border-radius: var(--global-br);
+  font-size: var(--global-fz-md);
+  line-height: var(--global-lh);
+}
+
+.show-item p {
+  margin: 0;
+  padding: 1em 0;
+  border-top: solid var(--global-bw) var(--global-bc-muted);
+}
+
+.show-item p:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.show-item p:last-child {
+  padding-bottom: 0;
+}
+
+.show-item p strong {
+  font-size: var(--global-label-fz);
+}
+
+.show-item img {
+  max-height: 400px;
+  display: block;
+  margin: 12px auto 0;
+  object-fit: contain;
+}
+
+/****************
+New and Edit
+****************/
+
+form:not(.button_to) {
+  --main-button-fz: 16px;
+  --main-button-w: 160px;
+  --main-button-h: 44px;
+  --main-button-mt: 24px;
+  max-width: var(--single-column-w);
+}
+
+form div:not(:first-of-type) {
+  margin-top: 1em;
+  line-height: var(--global-lh);
+}
+
+form div:last-of-type {
+  margin-top: var(--main-button-mt);
+}
+
+form label,
+form em,
+.field i {
+  font-size: 0.8em;
+  font-weight: bold;
+  margin-bottom: 0.25em;
+  font-style: normal;
+}
+
+form input[type="text"],
+form input[type="email"],
+form input[type="password"],
+form textarea {
+  width: 100%;
+  padding: 6px;
+  line-height: inherit;
+  border: solid var(--global-bw) var(--global-bc);
+  border-radius: var(--global-br);
+}
+
+form textarea {
+  height: 200px;
+}
+
+form input[type="submit"] {
+  font-size: var(--main-button-fz);
+  min-width: var(--main-button-w);
+  height: var(--main-button-h);
+  background-color: var(--global-primary-c);
+  border: solid 1px var(--global-primary-c-hover);
+  border-radius: var(--global-br);
+  color: #fff;
+  font-weight: bold;
+}
+
+form input[type="submit"]:hover {
+  background-color: var(--global-primary-c-hover);
+}

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,21 +1,22 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong>Title:</strong>
+    <strong><%= t("title") %></strong>
+    
     <%= book.title %>
   </p>
 
   <p>
-    <strong>Memo:</strong>
+    <strong><%= t("memo") %></strong>
     <%= book.memo %>
   </p>
 
   <p>
-    <strong>Author:</strong>
+    <strong><%= t("author") %></strong>
     <%= book.author %>
   </p>
 
   <p>
-    <strong>Picture:</strong>
+    <strong><%= t("picture") %></strong>
     <%= image_tag(book.picture_url) if book.picture.present? %>
   </p>
 

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,7 +1,6 @@
 <div id="<%= dom_id book %>">
   <p>
     <strong><%= t("title") %></strong>
-    
     <%= book.title %>
   </p>
 

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,21 +1,21 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong><%= t("title") %></strong>
+    <strong><%= Book.human_attribute_name(:title) %></strong>
     <%= book.title %>
   </p>
 
   <p>
-    <strong><%= t("memo") %></strong>
+    <strong><%= Book.human_attribute_name(:memo) %></strong>
     <%= book.memo %>
   </p>
 
   <p>
-    <strong><%= t("author") %></strong>
+    <strong><%= Book.human_attribute_name(:author) %></strong>
     <%= book.author %>
   </p>
 
   <p>
-    <strong><%= t("picture") %></strong>
+    <strong><%= Book.human_attribute_name(:picture) %></strong>
     <%= image_tag(book.picture_url) if book.picture.present? %>
   </p>
 

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -4,7 +4,7 @@
 
 <br>
 
-<div>
+<nav class="page-nav">
   <%= link_to I18n.t("detail_book") , @book %> |
   <%= link_to I18n.t("back_books"), books_path %>
-</div>
+</nav>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,10 +1,10 @@
-<h1>Editing book</h1>
+<h1><%= t("edit_page") %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to "Show this book", @book %> |
-  <%= link_to "Back to books", books_path %>
+  <%= link_to I18n.t("detail_book") , @book %> |
+  <%= link_to I18n.t("back_books"), books_path %>
 </div>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -5,6 +5,6 @@
 <br>
 
 <nav class="page-nav">
-  <%= link_to I18n.t("detail_book") , @book %> |
-  <%= link_to I18n.t("back_books"), books_path %>
+  <%= link_to t("detail_book") , @book %> |
+  <%= link_to t("back_books"), books_path %>
 </nav>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -2,13 +2,16 @@
 
 <h1><%= t("index_page") %></h1>
 
-<div id="books">
+<div id="books" class="index-items">
   <% @books.each do |book| %>
-    <%= render book %>
-    <p>
-      <%= link_to I18n.t("detail_book"), book %>
-    </p>
+    <div class="index-item">
+      <%= render book %>
+      <p>
+        <%= link_to I18n.t("detail_book"), book %>
+      </p>
+    </div>
   <% end %>
 </div>
-
-<%= link_to I18n.t("new_book"), new_book_path %>
+<nav class="page-nav">
+  <%= link_to I18n.t("new_book"), new_book_path %>
+</nav>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p style="color: green"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t("index_page") %></h1>
 
 <div id="books">
   <% @books.each do |book| %>
     <%= render book %>
     <p>
-      <%= link_to "Show this book", book %>
+      <%= link_to I18n.t("detail_book"), book %>
     </p>
   <% end %>
 </div>
 
-<%= link_to "New book", new_book_path %>
+<%= link_to I18n.t("new_book"), new_book_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,9 +1,9 @@
-<h1>New book</h1>
+<h1><%= t("new_page") %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to "Back to books", books_path %>
+  <%= link_to I18n.t("back_books"), books_path %>
 </div>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -5,5 +5,5 @@
 <br>
 
 <nav class="page-nav">
-  <%= link_to I18n.t("back_books"), books_path %>
+  <%= link_to t("back_books"), books_path %>
 </nav>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -4,6 +4,6 @@
 
 <br>
 
-<div>
+<nav class="page-nav">
   <%= link_to I18n.t("back_books"), books_path %>
-</div>
+</nav>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,8 +3,8 @@
   <%= render @book %>
 </div>
   <nav class="page-nav">
-    <%= link_to  I18n.t("edit_book"), edit_book_path(@book) %> |
-    <%= link_to I18n.t("back_books") , books_path %>
+    <%= link_to  t("edit_book"), edit_book_path(@book) %> |
+    <%= link_to t("back_books") , books_path %>
 
-    <%= button_to I18n.t("destroy_book"), @book, method: :delete %>
+    <%= button_to t("destroy_book"), @book, method: :delete %>
   </nav>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,8 +3,8 @@
 <%= render @book %>
 
 <div>
-  <%= link_to "Edit this book", edit_book_path(@book) %> |
-  <%= link_to "Back to books", books_path %>
+  <%= link_to  I18n.t("edit_book"), edit_book_path(@book) %> |
+  <%= link_to I18n.t("back_books") , books_path %>
 
-  <%= button_to "Destroy this book", @book, method: :delete %>
+  <%= button_to I18n.t("destroy_book"), @book, method: :delete %>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,10 +1,10 @@
 <p style="color: green"><%= notice %></p>
-
-<%= render @book %>
-
-<div>
-  <%= link_to  I18n.t("edit_book"), edit_book_path(@book) %> |
-  <%= link_to I18n.t("back_books") , books_path %>
-
-  <%= button_to I18n.t("destroy_book"), @book, method: :delete %>
+<div class="show-item">
+  <%= render @book %>
 </div>
+  <nav class="page-nav">
+    <%= link_to  I18n.t("edit_book"), edit_book_path(@book) %> |
+    <%= link_to I18n.t("back_books") , books_path %>
+
+    <%= button_to I18n.t("destroy_book"), @book, method: :delete %>
+  </nav>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,8 +18,8 @@ module BooksApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.time_zone = 'Asia/Tokyo'
-    # config.i18n.default_locale = :ja
-    config.i18n.default_locale = :en
+    config.i18n.default_locale = :ja
+    # config.i18n.default_locale = :en
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,9 +17,9 @@ module BooksApp
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    config.time_zone = 'Asia/Tokyo'
-    config.i18n.default_locale = :ja
-    # config.i18n.default_locale = :en
+    # config.time_zone = 'Asia/Tokyo'
+    # config.i18n.default_locale = :ja
+    config.i18n.default_locale = :en
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,10 +17,9 @@ module BooksApp
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    # config.time_zone = 'Asia/Tokyo'
-    # config.i18n.default_locale = :ja
-
-    config.i18n.default_locale = :en
+    config.time_zone = 'Asia/Tokyo'
+    config.i18n.default_locale = :ja
+    # config.i18n.default_locale = :en
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ module BooksApp
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Asia/Tokyo'
+    config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,8 +17,10 @@ module BooksApp
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    config.time_zone = 'Asia/Tokyo'
-    config.i18n.default_locale = :ja
+    # config.time_zone = 'Asia/Tokyo'
+    # config.i18n.default_locale = :ja
+
+    config.i18n.default_locale = :en
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,6 @@ module BooksApp
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    # config.time_zone = 'Asia/Tokyo'
     config.i18n.default_locale = :ja
     # config.i18n.default_locale = :en
     # config.eager_load_paths << Rails.root.join("extras")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,16 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+
+  title: "Title:"
+  memo: "Memo:"
+  author: "Author:"
+  picture: "Picture:"
+  detail_book: "Show this book"
+  new_book: "New book"
+  edit_book: "Edit this book"
+  back_books: "Back to books"
+  destroy_book: "Destroy this book"
+  edit_page: "Editing book"
+  new_page: "New book"
+  index_page: "Books"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,29 @@
+ ja:
+  activerecord:
+    models:
+      book: 本
+    attributes:
+      book:
+        memo: メモ
+        author: 著者
+        title: タイトル
+        picture: 写真
+
+  title: "タイトル"
+  memo: "メモ"
+  author: "著者"
+  picture: "写真"
+  detail_book: "この本の詳細"
+  new_book: "本の登録"
+  edit_book: "本の編集"
+  back_books: "一覧へ戻る"
+  destroy_book: "本の削除"
+  edit_page: "本の編集"
+  new_page: "本の登録"
+  index_page: "本の一覧"
+
+  helpers:
+    submit:
+      create: '%{model}の登録'
+      update: '%{model}の更新'
+      submit: '%{model}の保存'


### PR DESCRIPTION
提出します。

- [x] 英語と日本語の翻訳をconfig/locales配下のYAMLファイルに定義する
- [x] 各画面の表示を翻訳ファイルから取得して表示できるようにする
- [x] デフォルトの表示言語を英語または日本語に切り替えることで、実際に画面の表示が英語と日本語に切り替わる（要スクリーンショット）
　別で添付します。

- [x] 表示を切り替えるときは「アプリケーションの設定ファイルを変更してサーバー再起動」でOK（ただし、提出時は日本語をデフォルトにすること）
- [ ] [Rails 国際化 (i18n) API - Railsガイド](https://railsguides.jp/i18n.html) を読み、使えそうなメソッドがあれば積極的に使う
　積極的に使えませんでした...

- [x] [このドキュメント](https://bootcamp.fjord.jp/pages/how-to-install-machida-special)を読んで、UIを見やすくする（ただし、Rails 6.1版は対応不要）
- [x] rubocopとerblintをパスさせる（要スクリーンショット）
　　別で添付します。
