### PR TITLE
日報の言及機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :test do
   gem 'selenium-webdriver'
 end
 
+gem 'rails_autolink'
 gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile
+++ b/Gemfile
@@ -82,8 +82,8 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-gem 'rails_autolink'
 gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'
 gem 'kaminari'
+gem 'rails_autolink'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_autolink (1.1.8)
+      actionview (> 3.1)
+      activesupport (> 3.1)
+      railties (> 3.1)
     railties (7.0.6)
       actionpack (= 7.0.6)
       activesupport (= 7.0.6)
@@ -328,6 +332,7 @@ DEPENDENCIES
   letter_opener_web
   puma
   rails (~> 7.0.6)
+  rails_autolink
   rubocop (~> 1.45.1)
   rubocop-fjord
   rubocop-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,4 @@ class ApplicationController < ActionController::Base
     user_path(current_user)
   end
 
-  def record_not_found
-    render plain: '404 Not Found', status: :not_found
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
@@ -24,5 +26,9 @@ class ApplicationController < ActionController::Base
 
   def signed_in_root_path(_resource_or_scope)
     user_path(current_user)
+  end
+
+  def record_not_found
+    render plain: '404 Not Found', status: :not_found
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,6 +22,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
+      update_mention
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -30,6 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
+      update_mention
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -40,6 +42,30 @@ class ReportsController < ApplicationController
     @report.destroy
 
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
+  end
+
+  def update_mention
+    mentioned_report_id = @report.id
+    mention_ids = mentioning_reports
+    create_mention_ids = mention_ids[:create_ids]
+    delete_mention_ids = mention_ids[:delete_ids]
+    create_mention_ids.each do |id|
+      mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
+      mention.save
+    end
+
+    mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
+    mention.delete if !mention.empty?
+  end
+
+  def mentioning_reports
+    mentioning_reports = @report.content.scan(%r{localhost:3000/reports/(\d+)}).flatten
+    mentioning_reports.uniq!
+    mentioning_reports.map!(&:to_i)
+
+    create_reports_ids = mentioning_reports - @report.mentioning_report_ids
+    delete_reports_ids = @report.mentioning_report_ids - mentioning_reports
+    { create_ids: create_reports_ids, delete_ids: delete_reports_ids }
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,7 +22,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
-      update_mention
+      Report.update_mention(@report)
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -31,7 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      update_mention
+      Report.update_mention(@report)
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
@@ -42,30 +42,6 @@ class ReportsController < ApplicationController
     @report.destroy
 
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
-  end
-
-  def update_mention
-    mentioned_report_id = @report.id
-    mention_ids = mentioning_reports
-    create_mention_ids = mention_ids[:create_ids]
-    delete_mention_ids = mention_ids[:delete_ids]
-    create_mention_ids.each do |id|
-      mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
-      mention.save
-    end
-
-    mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
-    mention.delete_all if !mention.empty?
-  end
-
-  def mentioning_reports
-    mentioning_reports = @report.content.scan(%r{localhost:3000/reports/(\d+)}).flatten
-    mentioning_reports.uniq!
-    mentioning_reports.map!(&:to_i)
-
-    create_reports_ids = mentioning_reports - @report.mentioning_report_ids
-    delete_reports_ids = @report.mentioning_report_ids - mentioning_reports
-    { create_ids: create_reports_ids, delete_ids: delete_reports_ids }
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,7 +20,7 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
-    has_no_validation_error, mention_errors = Report.save_or_update_with_transaction(@report)
+    has_no_validation_error, mention_errors = @report.save_with_transaction
 
     if has_no_validation_error
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
@@ -31,7 +31,7 @@ class ReportsController < ApplicationController
   end
 
   def update
-    has_no_validation_error, mention_errors = Report.save_or_update_with_transaction(@report, report_params)
+    has_no_validation_error, mention_errors = @report.save_with_transaction(report_params)
 
     if has_no_validation_error
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,7 +20,7 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
-    has_no_validation_error, mention_errors = @report.save_with_transaction
+    has_no_validation_error, mention_errors = @report.save_with_mentions
 
     if has_no_validation_error
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
@@ -31,7 +31,7 @@ class ReportsController < ApplicationController
   end
 
   def update
-    has_no_validation_error, mention_errors = @report.save_with_transaction(report_params)
+    has_no_validation_error, mention_errors = @report.save_with_mentions(report_params)
 
     if has_no_validation_error
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -55,7 +55,7 @@ class ReportsController < ApplicationController
     end
 
     mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
-    mention.delete if !mention.empty?
+    mention.delete_all if !mention.empty?
   end
 
   def mentioning_reports

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,20 +20,23 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
+    has_no_validation_error, mention_errors = Report.save_or_update_with_transaction(@report)
 
-    if @report.save
-      Report.update_mention(@report)
+    if has_no_validation_error
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
+      @report.errors.merge!(mention_errors)
       render :new, status: :unprocessable_entity
     end
   end
 
   def update
-    if @report.update(report_params)
-      Report.update_mention(@report)
+    has_no_validation_error, mention_errors = Report.save_or_update_with_transaction(@report, report_params)
+
+    if has_no_validation_error
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
+      @report.errors.merge!(mention_errors)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,0 +1,7 @@
+class Mention < ApplicationRecord
+  belongs_to :mentioning_report, class_name: 'Report', foreign_key: 'mentioning_report_id'
+  belongs_to :mentioned_report, class_name: 'Report', foreign_key: 'mentioned_report_id'
+  validates :mentioning_report_id, presence: true
+  validates :mentioned_report_id, presence: true
+  validates_uniqueness_of :mentioning_report_id, scope: :mentioned_report_id
+end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class Mention < ApplicationRecord
-  belongs_to :mentioning_report, class_name: 'Report', foreign_key: 'mentioning_report_id'
-  belongs_to :mentioned_report, class_name: 'Report', foreign_key: 'mentioned_report_id'
+  belongs_to :mentioning_report, class_name: 'Report'
+  belongs_to :mentioned_report, class_name: 'Report'
   validates :mentioning_report_id, presence: true
   validates :mentioned_report_id, presence: true
-  validates_uniqueness_of :mentioning_report_id, scope: :mentioned_report_id
+  validates :mentioning_report_id, uniqueness: { scope: :mentioned_report_id }
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -33,13 +33,13 @@ class Report < ApplicationRecord
                                  end
       raise ActiveRecord::Rollback if !has_no_validation_error
 
-      has_no_mention_error, mention_errors = update_mention
+      has_no_mention_error, mention_errors = update_mentions
       has_no_validation_error &= has_no_mention_error
     end
     [has_no_validation_error, mention_errors]
   end
 
-  def update_mention
+  def update_mentions
     has_no_mention_error = true
     mentioned_report_id = id
     mention_errors = ActiveModel::Errors.new(self)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,7 +49,7 @@ class Report < ApplicationRecord
     create_mention_ids.each do |id|
       mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
       has_no_mention_error &= mention.save
-      mention_errors.merge!(mention.errors) if !mention.errors.empty?
+      mention_errors.merge!(mention.errors) if mention.errors.any?
     end
     mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
     mention.delete_all if mention.exists?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -20,4 +20,28 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
+
+  def self.update_mention(report)
+    mentioned_report_id = report.id
+    mention_ids = mentioning_reports(report)
+    create_mention_ids = mention_ids[:create_ids]
+    delete_mention_ids = mention_ids[:delete_ids]
+    create_mention_ids.each do |id|
+      mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
+      mention.save
+    end
+
+    mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
+    mention.delete_all if !mention.empty?
+  end
+
+  def self.mentioning_reports(report)
+    mentioning_reports = report.content.scan(%r{localhost:3000/reports/(\d+)}).flatten
+    mentioning_reports.uniq!
+    mentioning_reports.map!(&:to_i)
+
+    create_reports_ids = mentioning_reports - report.mentioning_report_ids
+    delete_reports_ids = report.mentioning_report_ids - mentioning_reports
+    { create_ids: create_reports_ids, delete_ids: delete_reports_ids }
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,6 +35,7 @@ class Report < ApplicationRecord
 
       has_no_mention_error, mention_errors = update_mentions
       has_no_validation_error &= has_no_mention_error
+      raise ActiveRecord::Rollback if !has_no_validation_error
     end
     [has_no_validation_error, mention_errors]
   end
@@ -49,7 +50,10 @@ class Report < ApplicationRecord
     create_mention_ids.each do |id|
       mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
       has_no_mention_error &= mention.save
-      mention_errors.merge!(mention.errors) if mention.errors.any?
+      if mention.errors.any?
+        mention_errors.merge!(mention.errors)
+        break
+      end
     end
     mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
     mention.delete_all if mention.exists?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,6 +4,13 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
+  has_many :mentions_as_source, class_name: 'Mention', foreign_key: 'mentioning_report_id', dependent: :destroy
+  has_many :mentioned_reports, through: :mentions_as_source
+
+  has_many :mentions_as_target, class_name: 'Mention', foreign_key: 'mentioned_report_id', dependent: :destroy
+  has_many :mentioning_reports, through: :mentions_as_target
+
+  
   validates :title, presence: true
   validates :content, presence: true
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,10 +49,10 @@ class Report < ApplicationRecord
     create_mention_ids.each do |id|
       mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
       has_no_mention_error &= mention.save
-      mention_errors.merge!(mention.errors) if !mention.errors.empty?
+      mention_errors.merge!(mention.errors) if mention.errors.exists?
     end
     mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
-    mention.delete_all if !mention.empty?
+    mention.delete_all if mention.exists?
     [has_no_mention_error, mention_errors]
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -31,10 +31,10 @@ class Report < ApplicationRecord
                                  else
                                    report.save
                                  end
+      raise ActiveRecord::Rollback if !has_no_validation_error
 
       has_no_mention_error, mention_errors = Report.update_mention(report)
       has_no_validation_error &= has_no_mention_error
-      raise ActiveRecord::Rollback if !has_no_validation_error
     end
     [has_no_validation_error, mention_errors]
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -21,7 +21,7 @@ class Report < ApplicationRecord
     created_at.to_date
   end
 
-  def save_with_transaction(report_params = nil)
+  def save_with_mentions(report_params = nil)
     has_no_validation_error = true
     has_no_mention_error = true
     mention_errors = ActiveModel::Errors.new(self)
@@ -49,7 +49,7 @@ class Report < ApplicationRecord
     create_mention_ids.each do |id|
       mention = Mention.new(mentioning_report_id: id, mentioned_report_id:)
       has_no_mention_error &= mention.save
-      mention_errors.merge!(mention.errors) if mention.errors.exists?
+      mention_errors.merge!(mention.errors) if !mention.errors.empty?
     end
     mention = Mention.where(mentioning_report_id: delete_mention_ids, mentioned_report_id:)
     mention.delete_all if mention.exists?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,13 +4,12 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
-  has_many :mentions_as_source, class_name: 'Mention', foreign_key: 'mentioning_report_id', dependent: :destroy
+  has_many :mentions_as_source, class_name: 'Mention', foreign_key: 'mentioning_report_id', inverse_of: :mentioned_report, dependent: :destroy
   has_many :mentioned_reports, through: :mentions_as_source
 
-  has_many :mentions_as_target, class_name: 'Mention', foreign_key: 'mentioned_report_id', dependent: :destroy
+  has_many :mentions_as_target, class_name: 'Mention', foreign_key: 'mentioned_report_id', inverse_of: :mentioning_report, dependent: :destroy
   has_many :mentioning_reports, through: :mentions_as_target
 
-  
   validates :title, presence: true
   validates :content, presence: true
 

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:content) %>:</strong>
-    <%= format_content report.content %>
+    <%= auto_link(format_content(report.content)) %>
   </p>
 
   <p>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -4,6 +4,17 @@
   <%= render @report %>
 </div>
 
+<% if !@report.mentioned_reports.empty? %>
+<h2>この日報に言及している日報</h2>
+  <ul>
+    <% @report.mentioned_reports.each do |report| %>
+      <li>
+      <%= link_to report.title , report %> <%= report.user.name %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
 <%= render 'shared/comments', commentable: @report %>
 
 <nav class="page-nav">

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,3 +23,8 @@ ja:
         content: 内容
         user: 作成者
         created_on: 作成日
+        mentioning_report_id: 言及している記事のid
+        mentioned_report_id: 言及された記事のid
+      mention:
+        mentioning_report_id: 言及している記事id
+        mentioned_report_id: 言及された記事id

--- a/db/migrate/20231116201637_create_mentions.rb
+++ b/db/migrate/20231116201637_create_mentions.rb
@@ -5,5 +5,7 @@ class CreateMentions < ActiveRecord::Migration[7.0]
       t.references :mentioned_report, foreign_key: { to_table: :reports }
       t.timestamps
     end
+    
+    add_index :mentions, [:mentioning_report_id, :mentioned_report_id], unique: true
   end
 end

--- a/db/migrate/20231116201637_create_mentions.rb
+++ b/db/migrate/20231116201637_create_mentions.rb
@@ -1,0 +1,9 @@
+class CreateMentions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :mentions do |t|
+      t.references :mentioning_report, foreign_key: { to_table: :reports }
+      t.references :mentioned_report, foreign_key: { to_table: :reports }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231116201637_create_mentions.rb
+++ b/db/migrate/20231116201637_create_mentions.rb
@@ -1,8 +1,8 @@
 class CreateMentions < ActiveRecord::Migration[7.0]
   def change
     create_table :mentions do |t|
-      t.references :mentioning_report, foreign_key: { to_table: :reports }
-      t.references :mentioned_report, foreign_key: { to_table: :reports }
+      t.references :mentioning_report, foreign_key: { to_table: :reports } ,null: false
+      t.references :mentioned_report, foreign_key: { to_table: :reports } ,null: false
       t.timestamps
     end
     

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -60,8 +60,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   end
 
   create_table "mentions", force: :cascade do |t|
-    t.integer "mentioning_report_id"
-    t.integer "mentioned_report_id"
+    t.integer "mentioning_report_id", null: false
+    t.integer "mentioned_report_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["mentioned_report_id"], name: "index_mentions_on_mentioned_report_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "mentions", force: :cascade do |t|
+    t.integer "mentioning_report_id"
+    t.integer "mentioned_report_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mentioned_report_id"], name: "index_mentions_on_mentioned_report_id"
+    t.index ["mentioning_report_id"], name: "index_mentions_on_mentioning_report_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -87,5 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "mentions", "reports", column: "mentioned_report_id"
+  add_foreign_key "mentions", "reports", column: "mentioning_report_id"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_201637) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["mentioned_report_id"], name: "index_mentions_on_mentioned_report_id"
+    t.index ["mentioning_report_id", "mentioned_report_id"], name: "index_mentions_on_mentioning_report_id_and_mentioned_report_id", unique: true
     t.index ["mentioning_report_id"], name: "index_mentions_on_mentioning_report_id"
   end
 


### PR DESCRIPTION
提出します。

## 必須要件

- [x] Aさんの日報の本文テキストにBさんの日報のURL（ http://localhost:3000/reports/44 など）が含まれていると、Bさんの日報に「この日報に言及している日報」としてAさんの日報が表示される
- [x] 日報の新規作成時だけでなく更新時や削除時も言及が更新される（本文テキストから日報のURLがなくなったら言及もなくなる）

以下2点は提出物のリンクに貼っています。
- [x] 実装した機能の動きがわかるスクショを載せる
- [x] rubocopとerblintをパスさせる（要スクリーンショット）

## 歓迎要件

- [x] 日報の本文テキストにURLが含まれていた場合は自動的にリンクにする